### PR TITLE
EXP-6: Scaffold hopping (D9 Riniker-Landrum)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 cache/
 results/
 figures/
+logs/
+scratch/
 eddde/local_settings.py
 
 # Byte-compiled / optimized / DLL files

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -234,7 +234,7 @@ Bridges Strain A (features only) and Strain C (geometry-dominant). All variants 
 | D6 | Activity cliff pairs (30 ChEMBL targets) | EXP-4 | **Primary**: MoleculeACE pre-curated data — [github.com/molML/MoleculeACE/tree/main/MoleculeACE/Data/benchmark_data](https://github.com/molML/MoleculeACE/tree/main/MoleculeACE/Data/benchmark_data) / [van Tilborg et al. 2022](https://doi.org/10.1021/acs.jcim.2c01073). **Fallback** (if cliff definition needs to be MMP-only): current ChEMBL release + `mmpdb`; method: [Hu et al. 2012](https://doi.org/10.1021/ci3001138) |
 | D7 | SwissBioisostere replacements | EXP-5a | [swissbioisostere.ch](http://www.swissbioisostere.ch) / [Isert et al. 2022](https://doi.org/10.1093/nar/gkab1047) |
 | D8 | Curated classical bioisostere pairs | EXP-5b | Literature-based list, ~50–100 pairs; seed list from [Meanwell 2011](https://doi.org/10.1021/jm1013693) |
-| D9 | Riniker-Landrum 88-target benchmark | EXP-6 | [github.com/rdkit/benchmarking_platform](https://github.com/rdkit/benchmarking_platform) / [Riniker & Landrum 2013](https://doi.org/10.1186/1758-2946-5-26) |
+| D9 | Riniker-Landrum benchmark (37 ChEMBL_II targets used; "88" is the original MUV+DUD+ChEMBL union — see §5.8 note) | EXP-6 | [github.com/rdkit/benchmarking_platform](https://github.com/rdkit/benchmarking_platform) / [Riniker & Landrum 2013](https://doi.org/10.1186/1758-2946-5-26) |
 
 **Known dataset issues to document in results:**
 - D5 (DUD-E) is **deferred** — see EXP-3c §5.5 for rationale. The known analog bias and property shortcuts ([Chen et al. 2019](https://doi.org/10.1371/journal.pone.0220113)) make D3+D4 a more rigorous test of the same hypothesis at ~25 % of the compute cost. If D5 is later run, report both the full 102-target set and the bias-reduced ~47-target subset from [Lagarde et al. 2015](https://doi.org/10.1021/acs.jcim.5b00090), and weight results below D3 and D4 in final conclusions.
@@ -371,6 +371,7 @@ All experiments produce MUT results and corresponding results for every applicab
 - **Type**: external
 - **Question**: Does MUT retrieve actives with diverse scaffolds, not just analogs of the query?
 - **Data**: D9. 88 targets filtered for scaffold-hopping evaluation.
+  > **Note (implementation, 2026-06):** the EXP-6 implementation uses the **37 ChEMBL_II** targets, not 88. The Riniker-Landrum repo's `compounds/ChEMBL_II/` ships 37 targets (the ChEMBL-only VS subset with upstream scaffold clusters); the "88" figure is the original 2013 benchmark's MUV+DUD+ChEMBL union, which does not carry the scaffold annotations this experiment needs. The 37-target count is canonical for the code; the success criterion below should be read as "across the 37 targets". See `eddde/data/sources/rinlan.py` docstring for the full reconciliation.
 - **Protocol**:
   - For each target, select query; rank all compounds by distance.
   - Measure both overall enrichment and scaffold-level enrichment at 1%, 5%, 10% cutoffs.

--- a/eddde/data/__init__.py
+++ b/eddde/data/__init__.py
@@ -12,6 +12,7 @@ from .sources.subst_cyclohexanes import SubstCyclohexanes
 from .sources.hammett_series import HammettSeries
 from .sources.welqrate import ALL_WELQRATE
 from .sources.muv import ALL_MUV
+from .sources.rinlan import ALL_RINLAN
 
 
 DATASETS: dict[str, Dataset] = {}
@@ -34,4 +35,6 @@ _register(HammettSeries())
 for _ds in ALL_WELQRATE:
     _register(_ds)
 for _ds in ALL_MUV:
+    _register(_ds)
+for _ds in ALL_RINLAN:
     _register(_ds)

--- a/eddde/data/sources/rinlan.py
+++ b/eddde/data/sources/rinlan.py
@@ -30,12 +30,25 @@ documented in PROJECT_PLAN.md (see scratch/exp6_implementation_plan.md §11.1).
 Each target becomes one Dataset subclass so the runner can track caching and
 staleness per target independently — same pattern as muv.py and welqrate.py.
 
-build_smiles() output schema:
+build_smiles() output schema (flat — matches MUV / WelQrate):
     id            chembl_id for actives, "decoy_<external_id>" for decoys
     smiles        canonical SMILES
     activity      1 (active) | 0 (decoy)
-    scaffold_id   non-negative int for actives (preserved from upstream),
-                  -1 for decoys
+
+Scaffold membership is stored separately in a sidecar JSON next to the
+SMILES CSV:
+    cache/datasets/<id>/scaffolds.json
+        {chembl_id: [scaffold_id, ...]}   actives only; decoys absent
+
+The upstream pickle is a many-to-many (active, scaffold) mapping (the
+Schuffenhauer 2007 hierarchy stores each active under every ancestor
+scaffold it instantiates). Materializing that as duplicate CSV rows
+breaks the runner's "one row per molecule" invariant (dataset_size, the
+conformer / coeff / embedding dicts all dedupe silently and end up
+inconsistent with the SMILES row count), so we deduplicate by ChEMBL ID
+and persist the full scaffold set in the sidecar. EXP-6 reads the JSON
+to compute scaffold-aware metrics; downstream pipeline stages see a
+plain SMILES CSV indistinguishable from MUV's.
 """
 
 from __future__ import annotations
@@ -43,15 +56,17 @@ from __future__ import annotations
 import gzip
 import hashlib
 import io
+import json
 import pickle
 import subprocess
+from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 from ... import SEED
-from ..base import Dataset, CACHE_ROOT
+from ..base import Dataset, CACHE_ROOT, dataset_dir
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +118,7 @@ def _ensure_zinc_decoys() -> Path:
         return _ZINC_DECOYS_PATH
     _SHARED_RAW_DIR.mkdir(parents=True, exist_ok=True)
     url = f"{_RAW_BASE}/compounds/ChEMBL/cmp_list_ChEMBL_zinc_decoys.dat.gz"
-    print(f"[rinlan/shared] downloading ZINC decoy pool ...")
+    print(f"[_rinlan_shared:download] downloading ZINC decoy pool ...")
     _curl(url, _ZINC_DECOYS_PATH)
     return _ZINC_DECOYS_PATH
 
@@ -163,16 +178,25 @@ class _RinLanBase(Dataset):
         with open(actives_pkl, "rb") as f:
             scaf_to_actives = pickle.load(f, encoding="latin-1")
 
-        rows: list[dict] = []
+        # Upstream is a many-to-many (active, scaffold) mapping: the same
+        # ChEMBL ID can appear under multiple scaffold IDs (Schuffenhauer
+        # hierarchy — one entry per ancestor scaffold). Collapse to one row
+        # per molecule and persist the scaffold membership in the sidecar.
+        active_smiles: dict[str, str] = {}
+        scaffolds: dict[str, list[int]] = defaultdict(list)
         for scaf_id, active_list in scaf_to_actives.items():
             sid = int(scaf_id)  # upstream uses Decimal
             for chembl_id, smiles in active_list:
-                rows.append({
-                    "id": str(chembl_id),
-                    "smiles": str(smiles),
-                    "activity": 1,
-                    "scaffold_id": sid,
-                })
+                cid = str(chembl_id)
+                if cid not in active_smiles:
+                    active_smiles[cid] = str(smiles)
+                if sid not in scaffolds[cid]:
+                    scaffolds[cid].append(sid)
+
+        rows: list[dict] = [
+            {"id": cid, "smiles": smi, "activity": 1}
+            for cid, smi in active_smiles.items()
+        ]
 
         decoys = _read_zinc_decoys(zinc_pkl)
         rng = _seeded_rng(self._target_id)
@@ -184,17 +208,28 @@ class _RinLanBase(Dataset):
                 "id": f"decoy_{internal_id}",
                 "smiles": str(smiles),
                 "activity": 0,
-                "scaffold_id": -1,
             })
 
         df = pd.DataFrame(rows)
         df.to_csv(out, index=False)
-        n_act = int((df["activity"] == 1).sum())
-        n_dec = int((df["activity"] == 0).sum())
-        n_scaf = df.loc[df["activity"] == 1, "scaffold_id"].nunique()
+
+        # Sidecar: scaffold membership per active ChEMBL ID. Lives next to
+        # the SMILES CSV so it's bound to the dataset directory rather than
+        # the experiment; EXP-6 loads it on demand. Decoys are absent from
+        # the mapping (callers must default to "no scaffold" themselves).
+        scaffolds_json = dataset_dir(self.id) / "scaffolds.json"
+        scaffolds_json.write_text(
+            json.dumps({cid: sorted(sids) for cid, sids in scaffolds.items()},
+                       sort_keys=True)
+        )
+
+        n_act = len(active_smiles)
+        n_dec = len(df) - n_act
+        n_scaf = len({s for sids in scaffolds.values() for s in sids})
         print(
-            f"[{self.id}] wrote {len(df)} molecules to {out} "
-            f"({n_act} actives across {n_scaf} scaffolds, {n_dec} decoys)"
+            f"[{self.id}:smiles] wrote {len(df)} molecules to {out} "
+            f"({n_act} actives across {n_scaf} scaffolds, {n_dec} decoys); "
+            f"scaffold membership in {scaffolds_json.name}"
         )
 
     def test_mode_subsample(self, df: pd.DataFrame, n: int, rng):  # noqa: ANN001
@@ -218,7 +253,7 @@ def _make_dataset(target_id: str) -> _RinLanBase:
     cls = type(
         ds_id,
         (_RinLanBase,),
-        {"id": ds_id, "version": "v1", "_target_id": target_id},
+        {"id": ds_id, "version": "v2-dedup", "_target_id": target_id},
     )
     return cls()
 

--- a/eddde/data/sources/rinlan.py
+++ b/eddde/data/sources/rinlan.py
@@ -1,0 +1,227 @@
+"""Riniker-Landrum ChEMBL_II benchmark (D9) for EXP-6: 37 ChEMBL targets curated
+for retrospective virtual-screening and scaffold-hopping evaluation.
+
+Paper:  Riniker & Landrum, J. Cheminform. 2013, 5:26. doi:10.1186/1758-2946-5-26
+Source: rdkit/benchmarking_platform on GitHub.
+
+Data layout in the upstream repo:
+    compounds/ChEMBL_II/Target_no_<N>.pkl
+        Pickled defaultdict(scaffold_id -> [[chembl_id, smiles], ...]). Actives
+        of one target, pre-clustered by scaffold. We keep the scaffold_id as a
+        column in smiles.csv so EXP-6 can compute scaffold-aware metrics
+        without re-deriving Bemis-Murcko.
+    compounds/ChEMBL/cmp_list_ChEMBL_zinc_decoys.dat.gz
+        Shared ~10,000-compound ZINC decoy pool, used as the screening-library
+        background for every ChEMBL target (the original 2013 protocol uses it
+        the same way; the `firstchembl` flag in their scoring scripts reads it
+        once and reuses across targets). We mirror that: download once to a
+        shared raw dir, then deterministically sample DECOYS_PER_TARGET=1500
+        decoys per target seeded by sha256(SEED|dataset_id).
+
+Note on PROJECT_PLAN.md §5.8: the spec says "88 targets". The repo organizes
+into three subsets (per its README):
+  - subset I:           88 targets (MUV + DUD + ChEMBL combined)
+  - subset I filtered:  69 targets
+  - subset II:          37 targets from ChEMBL only — designed for VS use case
+Subset II is the right pool for EXP-6 because only its compounds ship with
+upstream scaffold clusters; MUV/DUD do not. The 37-target count should be
+documented in PROJECT_PLAN.md (see scratch/exp6_implementation_plan.md §11.1).
+
+Each target becomes one Dataset subclass so the runner can track caching and
+staleness per target independently — same pattern as muv.py and welqrate.py.
+
+build_smiles() output schema:
+    id            chembl_id for actives, "decoy_<external_id>" for decoys
+    smiles        canonical SMILES
+    activity      1 (active) | 0 (decoy)
+    scaffold_id   non-negative int for actives (preserved from upstream),
+                  -1 for decoys
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import pickle
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from ... import SEED
+from ..base import Dataset, CACHE_ROOT
+
+
+# ---------------------------------------------------------------------------
+# Catalogue: ChEMBL target IDs from compounds/ChEMBL_II/ (37 entries).
+# Verified via GitHub tree API on 2026-05-26.
+# ---------------------------------------------------------------------------
+
+RINLAN_TARGET_IDS: list[str] = [
+    "15", "25", "43", "51", "61", "65", "72", "87", "90", "93",
+    "100", "107", "108", "114", "121", "126", "130", "165", "259",
+    "10188", "10193", "10260", "10280", "10434", "10980",
+    "11140", "11365", "11489", "11534", "11575", "11631",
+    "12209", "12252", "12952", "13001", "17045", "19905",
+]
+
+
+_RAW_BASE = (
+    "https://raw.githubusercontent.com/rdkit/benchmarking_platform/master"
+)
+
+# Per-target decoy budget. Original Riniker-Landrum used 10 % of the full ZINC
+# decoy pool (~1000); 1500 keeps things in that order of magnitude while
+# leaving headroom for the project-wide element filter to drop a few percent.
+DECOYS_PER_TARGET = 1500
+
+# Shared raw-data location: the global ZINC decoy file is downloaded once and
+# reused for every Target_no_<N>. Per-target raw dirs link out to it rather
+# than re-downloading.
+_SHARED_RAW_DIR = CACHE_ROOT / "datasets" / "_rinlan_shared" / "raw"
+_ZINC_DECOYS_PATH = _SHARED_RAW_DIR / "zinc_decoys.dat.gz"
+
+
+# ---------------------------------------------------------------------------
+# Download helpers
+# ---------------------------------------------------------------------------
+
+def _curl(url: str, dest: Path) -> None:
+    result = subprocess.run(
+        ["curl", "-L", "--silent", "--show-error", "-o", str(dest), url],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"curl failed ({url}):\n{result.stderr}")
+
+
+def _ensure_zinc_decoys() -> Path:
+    """Download the shared ZINC decoy file once; reuse for every target."""
+    if _ZINC_DECOYS_PATH.exists():
+        return _ZINC_DECOYS_PATH
+    _SHARED_RAW_DIR.mkdir(parents=True, exist_ok=True)
+    url = f"{_RAW_BASE}/compounds/ChEMBL/cmp_list_ChEMBL_zinc_decoys.dat.gz"
+    print(f"[rinlan/shared] downloading ZINC decoy pool ...")
+    _curl(url, _ZINC_DECOYS_PATH)
+    return _ZINC_DECOYS_PATH
+
+
+def _ensure_actives_pkl(target_id: str, raw_dir: Path) -> Path:
+    raw_pkl = raw_dir / "actives.pkl"
+    if raw_pkl.exists():
+        return raw_pkl
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    url = f"{_RAW_BASE}/compounds/ChEMBL_II/Target_no_{target_id}.pkl"
+    print(f"[RinLan_{target_id}] downloading actives ...")
+    _curl(url, raw_pkl)
+    return raw_pkl
+
+
+def _read_zinc_decoys(path: Path) -> list[tuple[str, str]]:
+    """Parse the shared ZINC decoy file: rows of (external_id, internal_id, smiles).
+    Returns list of (internal_id, smiles) — internal_id is unique within the pool.
+    """
+    with gzip.open(path, "rt") as f:
+        text = f.read()
+    rows: list[tuple[str, str]] = []
+    for raw in io.StringIO(text):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        # external_id, internal_id, smiles
+        rows.append((parts[1], parts[2]))
+    return rows
+
+
+def _seeded_rng(target_id: str) -> np.random.Generator:
+    """Deterministic RNG per target, derived from project SEED so reruns
+    sample the same decoys regardless of machine or order."""
+    key = f"{SEED}|RinLan_{target_id}".encode()
+    seed_bytes = hashlib.sha256(key).digest()[:8]
+    return np.random.default_rng(int.from_bytes(seed_bytes, "big"))
+
+
+# ---------------------------------------------------------------------------
+# Base class — one subclass per target via factory below.
+# ---------------------------------------------------------------------------
+
+class _RinLanBase(Dataset):
+    has_native_conformers = False
+
+    _target_id: str = ""
+
+    def build_smiles(self, out: Path) -> None:
+        raw_dir = CACHE_ROOT / "datasets" / self.id / "raw"
+        actives_pkl = _ensure_actives_pkl(self._target_id, raw_dir)
+        zinc_pkl = _ensure_zinc_decoys()
+
+        with open(actives_pkl, "rb") as f:
+            scaf_to_actives = pickle.load(f, encoding="latin-1")
+
+        rows: list[dict] = []
+        for scaf_id, active_list in scaf_to_actives.items():
+            sid = int(scaf_id)  # upstream uses Decimal
+            for chembl_id, smiles in active_list:
+                rows.append({
+                    "id": str(chembl_id),
+                    "smiles": str(smiles),
+                    "activity": 1,
+                    "scaffold_id": sid,
+                })
+
+        decoys = _read_zinc_decoys(zinc_pkl)
+        rng = _seeded_rng(self._target_id)
+        budget = min(DECOYS_PER_TARGET, len(decoys))
+        chosen = rng.choice(len(decoys), size=budget, replace=False)
+        for i in chosen:
+            internal_id, smiles = decoys[int(i)]
+            rows.append({
+                "id": f"decoy_{internal_id}",
+                "smiles": str(smiles),
+                "activity": 0,
+                "scaffold_id": -1,
+            })
+
+        df = pd.DataFrame(rows)
+        df.to_csv(out, index=False)
+        n_act = int((df["activity"] == 1).sum())
+        n_dec = int((df["activity"] == 0).sum())
+        n_scaf = df.loc[df["activity"] == 1, "scaffold_id"].nunique()
+        print(
+            f"[{self.id}] wrote {len(df)} molecules to {out} "
+            f"({n_act} actives across {n_scaf} scaffolds, {n_dec} decoys)"
+        )
+
+    def test_mode_subsample(self, df: pd.DataFrame, n: int, rng):  # noqa: ANN001
+        """Keep every active, fill remainder with random decoys.
+
+        Uniform random would drop most actives at typical hit rates (~10 %),
+        leaving too few to compute EF/ScafEF. Mirrors the WelQrate policy.
+        """
+        actives = df[df["activity"] == 1]
+        decoys = df[df["activity"] == 0]
+        budget = max(0, n - len(actives))
+        if budget < len(decoys):
+            decoys = decoys.sample(n=budget, random_state=rng)
+        return pd.concat([actives, decoys]).reset_index(drop=True)
+
+    test_mode_version = "v1-keep-actives"
+
+
+def _make_dataset(target_id: str) -> _RinLanBase:
+    ds_id = f"RinLan_{target_id}"
+    cls = type(
+        ds_id,
+        (_RinLanBase,),
+        {"id": ds_id, "version": "v1", "_target_id": target_id},
+    )
+    return cls()
+
+
+ALL_RINLAN: list[_RinLanBase] = [_make_dataset(t) for t in RINLAN_TARGET_IDS]
+RINLAN_DATASET_IDS: list[str] = [ds.id for ds in ALL_RINLAN]

--- a/eddde/experiments/__init__.py
+++ b/eddde/experiments/__init__.py
@@ -6,6 +6,7 @@ from .exp1_homologous import Exp1Homologous
 from .exp2_functional_group import Exp2FunctionalGroup
 from .exp3a_welqrate import Exp3aWelQrate
 from .exp3b_muv import Exp3bMUV
+from .exp6_scaffold_hopping import Exp6ScaffoldHopping
 
 
 EXPERIMENTS: dict[str, Experiment] = {}
@@ -21,3 +22,4 @@ _register(Exp1Homologous())
 _register(Exp2FunctionalGroup())
 _register(Exp3aWelQrate())
 _register(Exp3bMUV())
+_register(Exp6ScaffoldHopping())

--- a/eddde/experiments/exp6_scaffold_hopping.py
+++ b/eddde/experiments/exp6_scaffold_hopping.py
@@ -23,12 +23,18 @@ intended. Membership is many-to-many (Schuffenhauer hierarchy: one active
 can belong to multiple scaffold buckets), stored in the dataset's sidecar
 `cache/datasets/<id>/scaffolds.json` as {chembl_id: [scaf_id, ...]}.
 
-Status: Step 4 of scratch/exp6_implementation_plan.md. Sub-experiments A
-covers M-EF5, M-SCAFEF5, and M-SCAFRATIO. Sub-experiment B (leave-one-
-scaffold-out / M-RECALL-HELDOUT-SCAFFOLD) arrives in Step 5.
+Status: Step 5 of scratch/exp6_implementation_plan.md. Both sub-
+experiments implemented:
+  A: M-EF5, M-SCAFEF5, M-SCAFRATIO over 5 random query draws per target.
+  B: M-RECALL-HELDOUT-SCAFFOLD at 1/5/10 % via leave-one-scaffold-out on
+     targets with >= 5 distinct active scaffolds. Multi-bucket actives
+     appear as queries once per scaffold in their set — each (S, query)
+     pair tests one "perspective" on the chemistry.
 
 Output files written to `out/`:
   retrieval_standard.csv   (sub-experiment A, RETRIEVAL_COLS_EXP6 schema)
+  retrieval_heldout.csv    (sub-experiment B, RETRIEVAL_COLS_EXP6 schema;
+                            "seed" column carries the held-out scaffold S)
   metrics.json             (combined metric values)
 """
 from __future__ import annotations
@@ -58,6 +64,13 @@ N_QUERY_DRAWS = 5
 # (~100-1500 vs WelQrate's tens of thousands); the top 1 % cutoff would land
 # inside the first 5-10 ranks for small targets and bake in undue variance.
 EF_PERCENT_STANDARD = 5.0
+
+# Sub-experiment B eligibility floor and the percent cutoffs to report.
+MIN_SCAFFOLDS_FOR_HELDOUT = 5
+RECALL_PERCENTS = (1.0, 5.0, 10.0)
+# Which cutoff feeds the un-suffixed primary metric. 5 % matches M-EF5 and
+# is the spec's recommended default (plan §4.3 stratification note).
+RECALL_PRIMARY_PERCENT = 5.0
 
 
 # Extended schema: retrieval_common.RETRIEVAL_COLS plus the scaffold sets of
@@ -94,7 +107,7 @@ def _load_scaffold_map(dataset_id: str) -> dict[str, list[int]]:
 
 class Exp6ScaffoldHopping:
     id = "EXP-6"
-    version = "v0.3-scafef"
+    version = "v0.4-heldout"
     datasets = RINLAN_DATASET_IDS
 
     metric_direction = {
@@ -223,6 +236,78 @@ class Exp6ScaffoldHopping:
         metrics.update(rc.metric_entry("M-EF5",       seed_ef5))
         metrics.update(rc.metric_entry("M-SCAFEF5",   seed_scafef5))
         metrics.update(rc.metric_entry("M-SCAFRATIO", seed_scafratio))
+
+        # --- Sub-experiment B: leave-one-scaffold-out ---------------------
+        # Eligibility: targets must have at least MIN_SCAFFOLDS_FOR_HELDOUT
+        # distinct active scaffolds. Ineligible targets skip B entirely;
+        # M-RECALL-HELDOUT-SCAFFOLD is simply absent from their metrics.json
+        # and the SUMMARY table reads "—" for those cells.
+        distinct_scaffolds = sorted({s for sids in scaffold_map.values() for s in sids})
+        heldout_rows: list[dict] = []
+        recall_per_query: dict[float, list[float]] = {p: [] for p in RECALL_PERCENTS}
+
+        if len(distinct_scaffolds) >= MIN_SCAFFOLDS_FOR_HELDOUT and active_ids:
+            decoy_ids = [m for m in mol_ids if activity[m] == 0]
+            for s in distinct_scaffolds:
+                queries_s = [a for a in active_ids if s in scaffold_map.get(a, [])]
+                held_out_s = [a for a in active_ids if s not in scaffold_map.get(a, [])]
+                if not queries_s or not held_out_s:
+                    # Scaffold S where every active is also in some other bucket
+                    # that ends up being identical to S's bucket, or the
+                    # complement is empty — skip the round (no signal).
+                    continue
+
+                pool_s = decoy_ids + held_out_s
+                held_out_set = set(held_out_s)
+                n_total = len(pool_s)
+                n_targets = len(held_out_s)
+
+                # Queries-S and pool-S are disjoint by construction (queries
+                # have S in their scaffold set; held-out actives do not), so
+                # no self-column to remove.
+                D = pairwise_matrix(method, embeddings, queries_s, pool_s)
+
+                for i, q in enumerate(queries_s):
+                    q_scafs = scaffold_map.get(q, [])
+                    row = D[i]
+                    order = np.argsort(row, kind="stable")
+
+                    ranks_of_held_out: list[int] = []
+                    for rank_0, idx in enumerate(order):
+                        cid = pool_s[idx]
+                        if cid in held_out_set:
+                            rank = rank_0 + 1
+                            ranks_of_held_out.append(rank)
+                            heldout_rows.append({
+                                "seed": s,
+                                "query_id": q,
+                                "active_id": cid,
+                                "rank": rank,
+                                "distance": float(row[idx]),
+                                "n_total": n_total,
+                                "n_actives_in_pool": n_targets,
+                                "scaffold_ids": json.dumps(scaffold_map.get(cid, [])),
+                                "query_scaffold_ids": json.dumps(q_scafs),
+                            })
+
+                    for percent in RECALL_PERCENTS:
+                        recall_per_query[percent].append(
+                            rc.recall_at_percent(ranks_of_held_out, n_total,
+                                                 n_targets, percent=percent)
+                        )
+
+            pd.DataFrame(heldout_rows, columns=list(RETRIEVAL_COLS_EXP6)).to_csv(
+                out / "retrieval_heldout.csv", index=False)
+
+            for percent in RECALL_PERCENTS:
+                key = f"M-RECALL-HELDOUT-SCAFFOLD_at{int(percent)}pct"
+                metrics.update(rc.metric_entry(key, recall_per_query[percent]))
+            # Primary alias for the headline metric (un-suffixed) at the
+            # spec-recommended 5 % cutoff. Pulled from the suffixed mean/SE
+            # so there's exactly one source of truth.
+            primary_key = f"M-RECALL-HELDOUT-SCAFFOLD_at{int(RECALL_PRIMARY_PERCENT)}pct"
+            metrics["M-RECALL-HELDOUT-SCAFFOLD"]    = metrics[primary_key]
+            metrics["M-RECALL-HELDOUT-SCAFFOLD_se"] = metrics[f"{primary_key}_se"]
 
         (out / "metrics.json").write_text(rc.metrics_to_json(metrics))
         return metrics

--- a/eddde/experiments/exp6_scaffold_hopping.py
+++ b/eddde/experiments/exp6_scaffold_hopping.py
@@ -49,6 +49,7 @@ import numpy as np
 import pandas as pd
 
 from .. import SEED
+from ..cache import hash_file, is_stale, write_manifest
 from ..data.base import Stage, dataset_dir
 from ..data.sources.rinlan import RINLAN_DATASET_IDS
 from ..methods.distance import pairwise_matrix
@@ -71,6 +72,11 @@ RECALL_PERCENTS = (1.0, 5.0, 10.0)
 # Which cutoff feeds the un-suffixed primary metric. 5 % matches M-EF5 and
 # is the spec's recommended default (plan §4.3 stratification note).
 RECALL_PRIMARY_PERCENT = 5.0
+
+# Curve-cache filenames, one per retrieval CSV (write_enrichment_summary
+# would collide otherwise — the helper writes to a single npz per call).
+NPZ_STANDARD = "enrichment_curve_standard.npz"
+NPZ_HELDOUT  = "enrichment_curve_heldout.npz"
 
 
 # Extended schema: retrieval_common.RETRIEVAL_COLS plus the scaffold sets of
@@ -107,7 +113,7 @@ def _load_scaffold_map(dataset_id: str) -> dict[str, list[int]]:
 
 class Exp6ScaffoldHopping:
     id = "EXP-6"
-    version = "v0.4-heldout"
+    version = "v0.5-plots"
     datasets = RINLAN_DATASET_IDS
 
     metric_direction = {
@@ -229,8 +235,10 @@ class Exp6ScaffoldHopping:
             seed_scafef5.append(scafef5)
             seed_scafratio.append(scafratio)
 
+        std_csv = out / "retrieval_standard.csv"
         pd.DataFrame(retrieval_rows, columns=list(RETRIEVAL_COLS_EXP6)).to_csv(
-            out / "retrieval_standard.csv", index=False)
+            std_csv, index=False)
+        rc.write_enrichment_summary(out, std_csv, npz_name=NPZ_STANDARD)
 
         metrics: dict = {}
         metrics.update(rc.metric_entry("M-EF5",       seed_ef5))
@@ -296,8 +304,10 @@ class Exp6ScaffoldHopping:
                                                  n_targets, percent=percent)
                         )
 
+            heldout_csv = out / "retrieval_heldout.csv"
             pd.DataFrame(heldout_rows, columns=list(RETRIEVAL_COLS_EXP6)).to_csv(
-                out / "retrieval_heldout.csv", index=False)
+                heldout_csv, index=False)
+            rc.write_enrichment_summary(out, heldout_csv, npz_name=NPZ_HELDOUT)
 
             for percent in RECALL_PERCENTS:
                 key = f"M-RECALL-HELDOUT-SCAFFOLD_at{int(percent)}pct"
@@ -311,6 +321,145 @@ class Exp6ScaffoldHopping:
 
         (out / "metrics.json").write_text(rc.metrics_to_json(metrics))
         return metrics
+
+    # ------------------------------------------------------------------
+    # Plotting
+    # ------------------------------------------------------------------
+
+    def _eligible_heldout_datasets(self, method_ids: list[str]) -> list[str]:
+        """Datasets where at least one method emitted retrieval_heldout.csv.
+
+        Eligibility is decided per-target at run-time (>= 5 active scaffolds);
+        we detect it post-hoc from the presence of the CSV rather than re-
+        reading scaffolds.json so plots stay in sync with what actually ran.
+        """
+        return [
+            ds for ds in self.datasets
+            if any(
+                (result_dir(self.id, m, ds) / "retrieval_heldout.csv").exists()
+                for m in method_ids
+            )
+        ]
+
+    def _plot_ef5_vs_scafef5(self, plots_dir: Path, method_ids: list[str]) -> None:
+        """One point per (method, dataset): x = M-EF5, y = M-SCAFEF5.
+
+        The y = x diagonal separates "scaffold-tracking matches actives-
+        tracking" (on the line) from "more scaffold-diverse than analog-
+        biased" (above the line). A horizontal line at 1.0 marks the random
+        baseline for SCAFEF5 alone.
+        """
+        import matplotlib.pyplot as plt
+
+        # Stable color per method across plots — uses matplotlib's tab cycle
+        # so we don't fix a palette that fights themes downstream.
+        cmap = plt.get_cmap("tab20")
+        method_color = {m: cmap(i % 20) for i, m in enumerate(method_ids)}
+
+        fig, ax = plt.subplots(figsize=(7, 7))
+        any_point = False
+        xs_all: list[float] = []
+        ys_all: list[float] = []
+        for m_id in method_ids:
+            xs: list[float] = []
+            ys: list[float] = []
+            for ds_id in self.datasets:
+                p = result_dir(self.id, m_id, ds_id) / "metrics.json"
+                if not p.exists():
+                    continue
+                data = json.loads(p.read_text())
+                ef5 = data.get("M-EF5")
+                scafef5 = data.get("M-SCAFEF5")
+                if ef5 is None or scafef5 is None:
+                    continue
+                xs.append(ef5)
+                ys.append(scafef5)
+            if not xs:
+                continue
+            any_point = True
+            xs_all.extend(xs)
+            ys_all.extend(ys)
+            ax.scatter(xs, ys, color=method_color[m_id], label=m_id, s=40,
+                       alpha=0.75, edgecolor="black", linewidth=0.4)
+
+        if not any_point:
+            plt.close(fig)
+            return
+
+        lo = min(0.0, min(xs_all), min(ys_all))
+        hi = max(max(xs_all), max(ys_all)) * 1.05
+        ax.plot([lo, hi], [lo, hi], color="grey", linestyle="--", linewidth=0.8,
+                label="y = x (analog = scaffold)")
+        ax.axhline(1.0, color="black", linestyle=":", linewidth=0.6,
+                   label="SCAFEF random baseline")
+        ax.set_xlim(lo, hi)
+        ax.set_ylim(lo, hi)
+        ax.set_xlabel("M-EF5 (active enrichment, top 5 %)")
+        ax.set_ylabel("M-SCAFEF5 (distinct-scaffold enrichment, top 5 %)")
+        ax.set_title(f"{self.id}: EF5 vs SCAFEF5 — scaffold tracking vs analog tracking")
+        ax.legend(fontsize=7, loc="best")
+        fig.tight_layout()
+        fig.savefig(plots_dir / "ef5_vs_scafef5.png", dpi=150, bbox_inches="tight")
+        plt.close(fig)
+
+    def make_plots(self, exp_results_dir: Path, method_ids: list[str]) -> None:
+        plots_dir = exp_results_dir / "plots"
+        plots_dir.mkdir(parents=True, exist_ok=True)
+
+        input_hashes: dict[str, str] = {}
+        for m_id in method_ids:
+            for ds_id in self.datasets:
+                for fname in ("retrieval_standard.csv", "retrieval_heldout.csv",
+                              "metrics.json"):
+                    p = result_dir(self.id, m_id, ds_id) / fname
+                    if p.exists():
+                        input_hashes[f"{m_id}/{ds_id}/{fname}"] = hash_file(p)
+
+        if not input_hashes:
+            return
+
+        sentinel = plots_dir / "enrichment_curves_standard.png"
+        if not is_stale(sentinel, self.version, input_hashes):
+            print(f"  [{self.id}] plots fresh")
+            return
+
+        print(f"  [{self.id}] generating plots...")
+
+        # 1) Sub-A enrichment curves (log-FPR vs TPR) — one panel per target.
+        rc.plot_enrichment_curves(
+            self.id, plots_dir, method_ids, self.datasets,
+            csv_name="retrieval_standard.csv",
+            npz_name=NPZ_STANDARD,
+            output_name="enrichment_curves_standard.png",
+            title_suffix=" — sub-A standard retrieval",
+        )
+
+        # 2) Methods × datasets heatmaps, one PNG per metric. The headline
+        #    is M-SCAFRATIO (scaffold-diversity heatmap from plan §7.2);
+        #    the rest are diagnostic.
+        rc.plot_metric_heatmap(
+            self.id, plots_dir, method_ids, self.datasets,
+            metrics=["M-EF5", "M-SCAFEF5", "M-SCAFRATIO",
+                     "M-RECALL-HELDOUT-SCAFFOLD"],
+        )
+
+        # 3) EF5 vs SCAFEF5 scatter — y = x is the "analog-tracking equals
+        #    scaffold-tracking" line; points above it favour hops over analogs.
+        self._plot_ef5_vs_scafef5(plots_dir, method_ids)
+
+        # 4) Sub-B held-out enrichment curves — only for eligible targets.
+        eligible = self._eligible_heldout_datasets(method_ids)
+        if eligible:
+            rc.plot_enrichment_curves(
+                self.id, plots_dir, method_ids, eligible,
+                csv_name="retrieval_heldout.csv",
+                npz_name=NPZ_HELDOUT,
+                output_name="enrichment_curves_heldout.png",
+                title_suffix=" — sub-B leave-one-scaffold-out",
+            )
+
+        write_manifest(sentinel, version=self.version, inputs=input_hashes,
+                       compute_time=0.0, dataset_size=0)
 
     def collect_results(self, method_ids: list[str]) -> pd.DataFrame:
         rows = []

--- a/eddde/experiments/exp6_scaffold_hopping.py
+++ b/eddde/experiments/exp6_scaffold_hopping.py
@@ -1,0 +1,177 @@
+"""EXP-6: Scaffold Hopping (PROJECT_PLAN.md §5.8).
+
+Question: Does a method retrieve actives with diverse scaffolds, not just
+analogs of the query?
+
+Two retrieval protocols rolled into one experiment, both per target:
+
+Sub-experiment A — standard retrieval (all 37 ChEMBL_II targets)
+  Draw 5 random query actives. Rank the entire pool (actives + decoys minus
+  query) by ascending distance. Compute M-EF5, M-SCAFEF5, M-SCAFRATIO.
+
+Sub-experiment B — leave-one-scaffold-out (targets with >=5 distinct active
+                   scaffolds only)
+  For each active scaffold S in target T:
+    queries = all actives with scaffold_id == S
+    pool    = decoys + actives with scaffold_id != S (held-out actives)
+  Compute M-RECALL-HELDOUT-SCAFFOLD at top 1 %, 5 %, 10 %.
+
+Scaffold partitions come pre-computed in the upstream Riniker-Landrum data
+(see eddde/data/sources/rinlan.py); we inherit them rather than re-deriving
+Bemis-Murcko, so the "scaffold" definition is the one the benchmark intended.
+
+Status: Step 3 of scratch/exp6_implementation_plan.md. Sub-experiment A is
+implemented and emits M-EF5; M-SCAFEF5, M-SCAFRATIO, and sub-experiment B
+arrive in Steps 4-5.
+
+Scaffold membership lives in `cache/datasets/<id>/scaffolds.json` as
+{chembl_id: [scaf_id, ...]}. Step 3 does not consume it; Step 4 will load
+it for SCAFEF/SCAFRATIO and rewrite the retrieval CSV schema to include
+the scaffold membership of each retrieved active.
+
+Output files written to `out/`:
+  retrieval_standard.csv   (sub-experiment A, retrieval_common.RETRIEVAL_COLS)
+  metrics.json             (combined metric values)
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .. import SEED
+from ..data.base import Stage
+from ..data.sources.rinlan import RINLAN_DATASET_IDS
+from ..methods.distance import pairwise_matrix
+from . import retrieval_common as rc
+from .base import result_dir
+
+
+# 5 random query actives per target — matches PROJECT_PLAN.md §5.8.
+N_QUERY_DRAWS = 5
+
+# Top-k percentage for the sub-experiment A enrichment factor. Wider than
+# EXP-3a/3b's 1 % because Riniker-Landrum targets have far fewer molecules
+# (~100-1500 vs WelQrate's tens of thousands); the top 1 % cutoff would land
+# inside the first 5-10 ranks for small targets and bake in undue variance.
+EF_PERCENT_STANDARD = 5.0
+
+
+def _seeded_rng(dataset_id: str, draw_idx: int) -> np.random.Generator:
+    """Deterministic RNG keyed on (global SEED, dataset, draw index).
+
+    Stable across machines/processes so reruns reproduce the same queries.
+    Same pattern as exp3b_muv._seeded_rng.
+    """
+    h = hashlib.sha256(f"{SEED}|{dataset_id}|{draw_idx}".encode()).digest()
+    return np.random.default_rng(int.from_bytes(h[:8], "big"))
+
+
+class Exp6ScaffoldHopping:
+    id = "EXP-6"
+    version = "v0.2-ef5-dedup"
+    datasets = RINLAN_DATASET_IDS
+
+    metric_direction = {
+        "M-EF5":                     +1,
+        "M-SCAFEF5":                 +1,
+        "M-SCAFRATIO":               +1,
+        "M-RECALL-HELDOUT-SCAFFOLD": +1,
+    }
+
+    # metric_datasets stays unset for now: only M-EF5 is emitted in this
+    # version, and SCAFEF/SCAFRATIO/RECALL-HELDOUT will gain a per-target
+    # eligibility map in Steps 4-5. SUMMARY.md treats absent metrics as "—".
+
+    def run(self, method, stage_data, embeddings, dataset_id: str, out: Path) -> dict[str, Any]:
+        df: pd.DataFrame = stage_data[Stage.SMILES].copy()
+        df["id"] = df["id"].astype(str)
+        out.mkdir(parents=True, exist_ok=True)
+
+        mol_ids: list[str] = df["id"].tolist()
+        activity: dict[str, int] = dict(zip(df["id"], df["activity"].astype(int)))
+        active_ids: list[str] = [m for m in mol_ids if activity[m] == 1]
+        n_actives_total = len(active_ids)
+
+        retrieval_rows: list[dict] = []
+        seed_ef5: list[float] = []
+
+        if active_ids:
+            # Independent seeded draws (collisions are vanishingly rare at
+            # typical ChEMBL_II active counts of 100-1000 per target; matches
+            # the MUV pattern for deterministic reproducibility).
+            draw_queries: list[str] = [
+                str(_seeded_rng(dataset_id, d).choice(active_ids))
+                for d in range(N_QUERY_DRAWS)
+            ]
+            # One batched pairwise_matrix call: (N_QUERY_DRAWS × n_pool).
+            # The full pool includes the query itself; we slice out its
+            # self-column from each row below.
+            D = pairwise_matrix(method, embeddings, draw_queries, mol_ids)
+            mol_col_of = {m: j for j, m in enumerate(mol_ids)}
+        else:
+            draw_queries = []
+            D = None
+            mol_col_of = {}
+
+        for draw_idx in range(N_QUERY_DRAWS):
+            if not active_ids:
+                seed_ef5.append(float("nan"))
+                continue
+
+            query_id = draw_queries[draw_idx]
+            self_col = mol_col_of[query_id]
+            row = D[draw_idx]
+            cand_mask = np.arange(len(mol_ids)) != self_col
+            candidates = [mol_ids[j] for j in range(len(mol_ids)) if j != self_col]
+            distances = row[cand_mask]
+            order = np.argsort(distances, kind="stable")
+
+            n_total = len(candidates)
+            n_actives = n_actives_total - 1  # query removed
+
+            active_ranks: list[int] = []
+            for rank_0, idx in enumerate(order):
+                cid = candidates[idx]
+                if activity[cid] == 1:
+                    rank = rank_0 + 1
+                    active_ranks.append(rank)
+                    retrieval_rows.append({
+                        "seed": draw_idx,
+                        "query_id": query_id,
+                        "active_id": cid,
+                        "rank": rank,
+                        "distance": float(distances[idx]),
+                        "n_total": n_total,
+                        "n_actives_in_pool": n_actives,
+                    })
+
+            seed_ef5.append(rc.ef_at_percent(active_ranks, n_total, n_actives,
+                                             percent=EF_PERCENT_STANDARD))
+
+        pd.DataFrame(retrieval_rows, columns=list(rc.RETRIEVAL_COLS)).to_csv(
+            out / "retrieval_standard.csv", index=False)
+
+        metrics: dict = {}
+        metrics.update(rc.metric_entry("M-EF5", seed_ef5))
+
+        (out / "metrics.json").write_text(rc.metrics_to_json(metrics))
+        return metrics
+
+    def collect_results(self, method_ids: list[str]) -> pd.DataFrame:
+        rows = []
+        for m_id in method_ids:
+            for ds_id in self.datasets:
+                p = result_dir(self.id, m_id, ds_id) / "metrics.json"
+                if not p.exists():
+                    continue
+                data = json.loads(p.read_text())
+                for metric in self.metric_direction:
+                    if metric in data:
+                        rows.append({"method": m_id, "dataset": ds_id,
+                                     "metric": metric, "value": data[metric]})
+        return pd.DataFrame(rows)

--- a/eddde/experiments/exp6_scaffold_hopping.py
+++ b/eddde/experiments/exp6_scaffold_hopping.py
@@ -12,31 +12,30 @@ Sub-experiment A — standard retrieval (all 37 ChEMBL_II targets)
 Sub-experiment B — leave-one-scaffold-out (targets with >=5 distinct active
                    scaffolds only)
   For each active scaffold S in target T:
-    queries = all actives with scaffold_id == S
-    pool    = decoys + actives with scaffold_id != S (held-out actives)
+    queries = all actives with S in their scaffold set
+    pool    = decoys + actives with S NOT in their scaffold set
   Compute M-RECALL-HELDOUT-SCAFFOLD at top 1 %, 5 %, 10 %.
 
 Scaffold partitions come pre-computed in the upstream Riniker-Landrum data
 (see eddde/data/sources/rinlan.py); we inherit them rather than re-deriving
-Bemis-Murcko, so the "scaffold" definition is the one the benchmark intended.
+Bemis-Murcko, so the "scaffold" definition is the one the benchmark
+intended. Membership is many-to-many (Schuffenhauer hierarchy: one active
+can belong to multiple scaffold buckets), stored in the dataset's sidecar
+`cache/datasets/<id>/scaffolds.json` as {chembl_id: [scaf_id, ...]}.
 
-Status: Step 3 of scratch/exp6_implementation_plan.md. Sub-experiment A is
-implemented and emits M-EF5; M-SCAFEF5, M-SCAFRATIO, and sub-experiment B
-arrive in Steps 4-5.
-
-Scaffold membership lives in `cache/datasets/<id>/scaffolds.json` as
-{chembl_id: [scaf_id, ...]}. Step 3 does not consume it; Step 4 will load
-it for SCAFEF/SCAFRATIO and rewrite the retrieval CSV schema to include
-the scaffold membership of each retrieved active.
+Status: Step 4 of scratch/exp6_implementation_plan.md. Sub-experiments A
+covers M-EF5, M-SCAFEF5, and M-SCAFRATIO. Sub-experiment B (leave-one-
+scaffold-out / M-RECALL-HELDOUT-SCAFFOLD) arrives in Step 5.
 
 Output files written to `out/`:
-  retrieval_standard.csv   (sub-experiment A, retrieval_common.RETRIEVAL_COLS)
+  retrieval_standard.csv   (sub-experiment A, RETRIEVAL_COLS_EXP6 schema)
   metrics.json             (combined metric values)
 """
 from __future__ import annotations
 
 import hashlib
 import json
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -44,7 +43,7 @@ import numpy as np
 import pandas as pd
 
 from .. import SEED
-from ..data.base import Stage
+from ..data.base import Stage, dataset_dir
 from ..data.sources.rinlan import RINLAN_DATASET_IDS
 from ..methods.distance import pairwise_matrix
 from . import retrieval_common as rc
@@ -61,6 +60,16 @@ N_QUERY_DRAWS = 5
 EF_PERCENT_STANDARD = 5.0
 
 
+# Extended schema: retrieval_common.RETRIEVAL_COLS plus the scaffold sets of
+# the retrieved active and the query, JSON-encoded so SCAFEF/SCAFRATIO are
+# recomputable straight from the CSV without re-loading scaffolds.json.
+RETRIEVAL_COLS_EXP6 = (
+    *rc.RETRIEVAL_COLS,
+    "scaffold_ids",
+    "query_scaffold_ids",
+)
+
+
 def _seeded_rng(dataset_id: str, draw_idx: int) -> np.random.Generator:
     """Deterministic RNG keyed on (global SEED, dataset, draw index).
 
@@ -71,9 +80,21 @@ def _seeded_rng(dataset_id: str, draw_idx: int) -> np.random.Generator:
     return np.random.default_rng(int.from_bytes(h[:8], "big"))
 
 
+def _load_scaffold_map(dataset_id: str) -> dict[str, list[int]]:
+    """Read the dataset's scaffolds.json sidecar (per-active scaffold lists).
+
+    Returns an empty dict if the sidecar is missing — keeps the experiment
+    safe to instantiate on datasets without scaffold annotation.
+    """
+    p = dataset_dir(dataset_id) / "scaffolds.json"
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text())
+
+
 class Exp6ScaffoldHopping:
     id = "EXP-6"
-    version = "v0.2-ef5-dedup"
+    version = "v0.3-scafef"
     datasets = RINLAN_DATASET_IDS
 
     metric_direction = {
@@ -83,9 +104,10 @@ class Exp6ScaffoldHopping:
         "M-RECALL-HELDOUT-SCAFFOLD": +1,
     }
 
-    # metric_datasets stays unset for now: only M-EF5 is emitted in this
-    # version, and SCAFEF/SCAFRATIO/RECALL-HELDOUT will gain a per-target
-    # eligibility map in Steps 4-5. SUMMARY.md treats absent metrics as "—".
+    # metric_datasets stays unset for now: M-EF5/SCAFEF5/SCAFRATIO apply to
+    # every target, M-RECALL-HELDOUT-SCAFFOLD will gain a per-target
+    # eligibility map (≥5 distinct active scaffolds) in Step 5. SUMMARY.md
+    # treats absent metrics as "—".
 
     def run(self, method, stage_data, embeddings, dataset_id: str, out: Path) -> dict[str, Any]:
         df: pd.DataFrame = stage_data[Stage.SMILES].copy()
@@ -97,8 +119,12 @@ class Exp6ScaffoldHopping:
         active_ids: list[str] = [m for m in mol_ids if activity[m] == 1]
         n_actives_total = len(active_ids)
 
+        scaffold_map = _load_scaffold_map(dataset_id)
+
         retrieval_rows: list[dict] = []
         seed_ef5: list[float] = []
+        seed_scafef5: list[float] = []
+        seed_scafratio: list[float] = []
 
         if active_ids:
             # Independent seeded draws (collisions are vanishingly rare at
@@ -121,9 +147,12 @@ class Exp6ScaffoldHopping:
         for draw_idx in range(N_QUERY_DRAWS):
             if not active_ids:
                 seed_ef5.append(float("nan"))
+                seed_scafef5.append(float("nan"))
+                seed_scafratio.append(float("nan"))
                 continue
 
             query_id = draw_queries[draw_idx]
+            query_scaffolds = scaffold_map.get(query_id, [])
             self_col = mol_col_of[query_id]
             row = D[draw_idx]
             cand_mask = np.arange(len(mol_ids)) != self_col
@@ -134,12 +163,27 @@ class Exp6ScaffoldHopping:
             n_total = len(candidates)
             n_actives = n_actives_total - 1  # query removed
 
+            # Per-scaffold active counts over THIS query's pool (query removed
+            # so its scaffolds don't inflate the random baseline).
+            scaffold_active_counts: dict[int, int] = defaultdict(int)
+            for cid in active_ids:
+                if cid == query_id:
+                    continue
+                for s in scaffold_map.get(cid, []):
+                    scaffold_active_counts[s] += 1
+
+            cutoff = max(1, int(np.ceil(n_total * EF_PERCENT_STANDARD / 100.0)))
+            retrieved_scaffold_sets: list[list[int]] = []
+
             active_ranks: list[int] = []
             for rank_0, idx in enumerate(order):
                 cid = candidates[idx]
                 if activity[cid] == 1:
                     rank = rank_0 + 1
                     active_ranks.append(rank)
+                    cid_scaf = scaffold_map.get(cid, [])
+                    if rank <= cutoff:
+                        retrieved_scaffold_sets.append(cid_scaf)
                     retrieval_rows.append({
                         "seed": draw_idx,
                         "query_id": query_id,
@@ -148,16 +192,37 @@ class Exp6ScaffoldHopping:
                         "distance": float(distances[idx]),
                         "n_total": n_total,
                         "n_actives_in_pool": n_actives,
+                        "scaffold_ids": json.dumps(cid_scaf),
+                        "query_scaffold_ids": json.dumps(query_scaffolds),
                     })
 
-            seed_ef5.append(rc.ef_at_percent(active_ranks, n_total, n_actives,
-                                             percent=EF_PERCENT_STANDARD))
+            ef5 = rc.ef_at_percent(active_ranks, n_total, n_actives,
+                                   percent=EF_PERCENT_STANDARD)
+            scafef5 = rc.scafef_at_percent(retrieved_scaffold_sets,
+                                           scaffold_active_counts,
+                                           n_total,
+                                           percent=EF_PERCENT_STANDARD)
+            # M-SCAFRATIO: per spec §5.2 it's literally SCAFEF / EF — measures
+            # whether the scaffolds-recovered enrichment outpaces the actives-
+            # recovered one (i.e. recovered actives are more scaffold-diverse
+            # than chance). Per-draw division, then mean across draws — keeps
+            # the SE behaviour consistent with the other metrics.
+            if ef5 != 0.0 and not (np.isnan(ef5) or np.isnan(scafef5)):
+                scafratio = scafef5 / ef5
+            else:
+                scafratio = float("nan")
 
-        pd.DataFrame(retrieval_rows, columns=list(rc.RETRIEVAL_COLS)).to_csv(
+            seed_ef5.append(ef5)
+            seed_scafef5.append(scafef5)
+            seed_scafratio.append(scafratio)
+
+        pd.DataFrame(retrieval_rows, columns=list(RETRIEVAL_COLS_EXP6)).to_csv(
             out / "retrieval_standard.csv", index=False)
 
         metrics: dict = {}
-        metrics.update(rc.metric_entry("M-EF5", seed_ef5))
+        metrics.update(rc.metric_entry("M-EF5",       seed_ef5))
+        metrics.update(rc.metric_entry("M-SCAFEF5",   seed_scafef5))
+        metrics.update(rc.metric_entry("M-SCAFRATIO", seed_scafratio))
 
         (out / "metrics.json").write_text(rc.metrics_to_json(metrics))
         return metrics

--- a/eddde/experiments/retrieval_common.py
+++ b/eddde/experiments/retrieval_common.py
@@ -284,13 +284,21 @@ def _build_curve_arrays(df: pd.DataFrame) -> tuple[np.ndarray, int]:
     return tpr_grid, n_curves
 
 
-def write_enrichment_summary(out_dir: Path, retrieval_csv: Path) -> None:
+def write_enrichment_summary(
+    out_dir: Path,
+    retrieval_csv: Path,
+    *,
+    npz_name: str = ENRICHMENT_CURVE_NPZ,
+) -> None:
     """Persist the 200-point TPR curve next to `retrieval_csv` as npz.
 
     Call from each experiment's `run()` immediately after writing the
     retrieval CSV. Plotting then loads tiny npz files instead of
     re-grouping millions of CSV rows. An empty CSV writes no npz —
     `_load_or_build_curve` treats absence as "skip this method".
+
+    Experiments that emit multiple retrieval CSVs (EXP-6: standard +
+    heldout) pass distinct `npz_name`s so the two curves don't collide.
     """
     df = read_csv_or_empty(retrieval_csv)
     if df.empty:
@@ -299,28 +307,33 @@ def write_enrichment_summary(out_dir: Path, retrieval_csv: Path) -> None:
     if n_curves == 0:
         return
     np.savez(
-        out_dir / ENRICHMENT_CURVE_NPZ,
+        out_dir / npz_name,
         log_fprs=LOG_FPR_GRID,
         tpr=tpr,
         n_curves=np.int64(n_curves),
     )
 
 
-def _load_or_build_curve(method_dir: Path) -> np.ndarray | None:
+def _load_or_build_curve(
+    method_dir: Path,
+    *,
+    csv_name: str = "retrieval_rankings.csv",
+    npz_name: str = ENRICHMENT_CURVE_NPZ,
+) -> np.ndarray | None:
     """Return the cached TPR array, building it from the CSV if missing.
 
     The npz is considered fresh when it exists and is at least as new as
     the source CSV. Stale npz files are rebuilt in place so older runs
     (from before this cache existed) self-heal on first plot.
     """
-    csv_path = method_dir / "retrieval_rankings.csv"
-    npz_path = method_dir / ENRICHMENT_CURVE_NPZ
+    csv_path = method_dir / csv_name
+    npz_path = method_dir / npz_name
     if not csv_path.exists():
         return None
     if npz_path.exists() and npz_path.stat().st_mtime >= csv_path.stat().st_mtime:
         with np.load(npz_path) as data:
             return data["tpr"].copy()
-    write_enrichment_summary(method_dir, csv_path)
+    write_enrichment_summary(method_dir, csv_path, npz_name=npz_name)
     if npz_path.exists():
         with np.load(npz_path) as data:
             return data["tpr"].copy()
@@ -332,12 +345,20 @@ def plot_enrichment_curves(
     plots_dir: Path,
     method_ids: list[str],
     datasets: list[str],
+    *,
+    csv_name: str = "retrieval_rankings.csv",
+    npz_name: str = ENRICHMENT_CURVE_NPZ,
+    output_name: str = "enrichment_curves.png",
+    title_suffix: str = "",
 ) -> None:
     """Log-scale ROC per dataset, one line per method (avg over seeds & queries).
 
-    Reads cached `enrichment_curve.npz` per (method, dataset) — built by
+    Reads cached enrichment-curve npz per (method, dataset) — built by
     `write_enrichment_summary` during `run()`. Falls back to recomputing
     + caching on the fly for older runs that predate the cache.
+
+    `csv_name` / `npz_name` / `output_name` let experiments with multiple
+    retrieval variants (EXP-6 standard vs heldout) emit separate plots.
     """
     fig, axes_flat = _per_dataset_grid(len(datasets))
 
@@ -352,7 +373,10 @@ def plot_enrichment_curves(
                 linestyle="--", label="random")
 
         for m_id in method_ids:
-            tpr = _load_or_build_curve(result_dir(exp_id, m_id, ds_id))
+            tpr = _load_or_build_curve(
+                result_dir(exp_id, m_id, ds_id),
+                csv_name=csv_name, npz_name=npz_name,
+            )
             if tpr is None:
                 continue
             ax.plot(LOG_FPR_GRID, tpr, linewidth=1.2, label=m_id)
@@ -363,9 +387,9 @@ def plot_enrichment_curves(
     for ax_idx in range(len(datasets), len(axes_flat)):
         axes_flat[ax_idx].set_visible(False)
 
-    fig.suptitle(f"{exp_id}: Log-scale enrichment curves (avg over queries & seeds)")
+    fig.suptitle(f"{exp_id}: Log-scale enrichment curves (avg over queries & seeds){title_suffix}")
     fig.tight_layout()
-    fig.savefig(plots_dir / "enrichment_curves.png", dpi=150, bbox_inches="tight")
+    fig.savefig(plots_dir / output_name, dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -391,18 +415,30 @@ def plot_metric_heatmap(
         if np.all(np.isnan(data_grid)):
             continue
 
-        fig, ax = plt.subplots(
-            figsize=(max(6, len(datasets) * 0.9),
-                     max(3, len(method_ids) * 0.6)),
-        )
-        im = ax.imshow(data_grid, aspect="auto", cmap="YlGn",
+        # Drop all-NaN columns so smoke runs (where most datasets are
+        # filtered out) don't render acres of empty cells. Full-mode runs
+        # have data in every column and this is a no-op.
+        keep = ~np.all(np.isnan(data_grid), axis=0)
+        data_grid = data_grid[:, keep]
+        kept_datasets = [d for d, k in zip(datasets, keep) if k]
+
+        # Cell-proportional figure size + aspect="equal" so cells stay square
+        # regardless of grid shape. The previous (max(6, n_ds*0.9), max(3,
+        # n_methods*0.6)) + aspect="auto" stretched cells flat when one axis
+        # dwarfed the other — e.g. 37 RinLan datasets × 2 methods produced
+        # 33×3 figures where each cell was 0.9 wide and ~1.5 tall.
+        cell = 0.55  # inches per cell; comfortable label readout
+        w = max(6.0, len(kept_datasets) * cell + 4.0)
+        h = max(3.0, len(method_ids) * cell + 2.5)
+        fig, ax = plt.subplots(figsize=(w, h))
+        im = ax.imshow(data_grid, aspect="equal", cmap="YlGn",
                        vmin=np.nanmin(data_grid), vmax=np.nanmax(data_grid))
-        ax.set_xticks(range(len(datasets)))
-        ax.set_xticklabels(datasets, rotation=45, ha="right", fontsize=8)
+        ax.set_xticks(range(len(kept_datasets)))
+        ax.set_xticklabels(kept_datasets, rotation=45, ha="right", fontsize=8)
         ax.set_yticks(range(len(method_ids)))
         ax.set_yticklabels(method_ids, fontsize=8)
         for i in range(len(method_ids)):
-            for j in range(len(datasets)):
+            for j in range(len(kept_datasets)):
                 v = data_grid[i, j]
                 if not np.isnan(v):
                     ax.text(j, i, f"{v:.3f}", ha="center", va="center", fontsize=7)

--- a/eddde/experiments/retrieval_common.py
+++ b/eddde/experiments/retrieval_common.py
@@ -104,6 +104,73 @@ def dcg_at_k(active_ranks, k: int = 100) -> float:
     return sum(1.0 / math.log2(r + 1) for r in active_ranks if r <= k)
 
 
+def _log_comb(n: int, k: int) -> float:
+    """Log of C(n, k) via lgamma — stable for the large pools EXP-6 sees."""
+    if k < 0 or k > n:
+        return float("-inf")
+    return math.lgamma(n + 1) - math.lgamma(k + 1) - math.lgamma(n - k + 1)
+
+
+def scafef_at_percent(
+    retrieved_scaffold_sets: list[list[int]],
+    scaffold_active_counts: dict[int, int],
+    n_total: int,
+    percent: float = 5.0,
+) -> float:
+    """Scaffold-aware enrichment factor at top-`percent`% of the ranking.
+
+    Numerator: distinct scaffolds in the union of scaffold sets of the
+        actives that ranked in the top-k% (where k = ceil(n_total*p/100)).
+    Denominator: expected count under uniformly random ranking.
+
+    Set semantics: each active carries the full list of scaffold buckets it
+    belongs to (from the dataset's scaffolds.json sidecar — Riniker-Landrum's
+    Schuffenhauer hierarchy can place an active in many buckets). An active
+    "hits" every scaffold in its set.
+
+    The denominator is computed exactly via the hypergeometric tail, no
+    Monte-Carlo or equal-cluster-size approximation:
+        P(scaffold s appears in top-k) = 1 - C(n_total - n_s, k) / C(n_total, k)
+    where n_s = number of pool actives whose scaffold set contains s. The
+    expectation is the sum over s of that probability. This is exact even
+    when actives belong to multiple buckets, so the analytical denominator
+    in the original plan (geometric approximation assuming equal cluster
+    sizes) is not needed.
+
+    Args:
+      retrieved_scaffold_sets: scaffold lists of the actives in top-k%.
+      scaffold_active_counts:  {scaffold_id: n_actives_in_pool_with_it}
+                               over the same pool (i.e. excluding the query).
+      n_total:                 pool size, excluding the query.
+      percent:                 top-k % cutoff.
+
+    Returns NaN if the pool or the scaffold count map is empty.
+    """
+    if n_total <= 0 or not scaffold_active_counts:
+        return float("nan")
+
+    k = max(1, math.ceil(n_total * percent / 100.0))
+    k = min(k, n_total)
+
+    observed = len({s for sids in retrieved_scaffold_sets for s in sids})
+
+    log_total = _log_comb(n_total, k)
+    expected = 0.0
+    for s, n_s in scaffold_active_counts.items():
+        if n_s <= 0:
+            continue
+        if n_total - n_s < k:
+            # All k-subsets must contain at least one s-bearing active.
+            expected += 1.0
+        else:
+            p_miss = math.exp(_log_comb(n_total - n_s, k) - log_total)
+            expected += 1.0 - p_miss
+
+    if expected <= 0:
+        return float("nan")
+    return observed / expected
+
+
 # ---------------------------------------------------------------------------
 # Aggregation helpers — silent over NaN so test-mode "no actives in this
 # split" cases don't drown the log in numpy warnings.

--- a/eddde/experiments/retrieval_common.py
+++ b/eddde/experiments/retrieval_common.py
@@ -104,6 +104,20 @@ def dcg_at_k(active_ranks, k: int = 100) -> float:
     return sum(1.0 / math.log2(r + 1) for r in active_ranks if r <= k)
 
 
+def recall_at_percent(ranks, n_total: int, n_targets: int, percent: float = 5.0) -> float:
+    """Fraction of `n_targets` whose rank falls within the top-`percent`%.
+
+    Used by EXP-6 sub-experiment B: ranks of held-out actives in a pool
+    of `n_total` candidates (decoys + held-out actives). Same cutoff
+    rule as ef_at_percent — ceil(n_total * p/100), 1-indexed ranks.
+    """
+    if n_targets == 0:
+        return float("nan")
+    cutoff = math.ceil(n_total * percent / 100.0)
+    tp = sum(1 for r in ranks if r <= cutoff)
+    return tp / n_targets
+
+
 def _log_comb(n: int, k: int) -> float:
     """Log of C(n, k) via lgamma — stable for the large pools EXP-6 sees."""
     if k < 0 or k > n:

--- a/experimental_plan.md
+++ b/experimental_plan.md
@@ -481,6 +481,8 @@ This stratification also dovetails with EXP-2 (Hammett series — pure electroni
 - Contains compound sets from three data sources: MUV, DUD, ChEMBL, with 88 targets after filtering.
 - Includes scaffold enrichment metrics specifically designed for scaffold hopping assessment.
 
+> **Note (implementation, 2026-06):** EXP-6 uses the **37 ChEMBL_II** targets, not the full 88. The repo's `compounds/ChEMBL_II/` ships 37 targets — the ChEMBL-only virtual-screening subset that carries upstream scaffold clusters. The "88" figure is the original 2013 MUV+DUD+ChEMBL union, whose MUV/DUD members lack the scaffold annotations this experiment needs. Read "88 targets" below as "37 ChEMBL_II targets". See `eddde/data/sources/rinlan.py` and `PROJECT_PLAN.md` §5.8 for the full reconciliation.
+
 **Procedure:**
 
 1. For each of the 88 targets and each method:
@@ -573,7 +575,7 @@ Rationale: a single minimum-energy conformer is the natural input for QM-derived
 | 3c | DUD-E retrieval | **Deferred** (see §4.3c) | 102 targets | AUC-ROC, BEDROC(20), EF₁% | Literature-comparable VS benchmark — implementation deferred, paper-time discussion required |
 | 4 | Activity cliff analysis | External | ~10,000 MMP pairs from ChEMBL | SALI, cliff detection AUC, distance–ΔpKi ρ | Sensitivity to potency-relevant changes |
 | 5 | Bioisostere recognition | External | SwissBioisostere + classical pairs | Bioisostere detection AUC, cross/within ratio | Functional equivalence beyond topology |
-| 6 | Scaffold hopping | External | 88 targets (Riniker & Landrum) | Scaffold-EF₅%, Scaffold-EF/EF ratio | Chemotype diversity in retrieval |
+| 6 | Scaffold hopping | External | 37 ChEMBL_II targets (Riniker & Landrum; see §EXP-6 note) | Scaffold-EF₅%, Scaffold-EF/EF ratio | Chemotype diversity in retrieval |
 
 ---
 


### PR DESCRIPTION
## Summary
  Adds EXP-6 (scaffold hopping) end-to-end on the D9 Riniker-Landrum
  ChEMBL_II benchmark (37 targets).
  
  - **Dataset (D9):** `eddde/data/sources/rinlan.py` — 37 ChEMBL_II targets,
    upstream scaffold clusters preserved in a `scaffolds.json` sidecar
    (many-to-many active↔scaffold).
  - **Experiment:** `eddde/experiments/exp6_scaffold_hopping.py`
    - Sub-A standard retrieval (5 random query draws): M-EF5, M-SCAFEF5, M-SCAFRATIO
    - Sub-A standard retrieval (5 random query draws): M-EF5, M-SCAFEF5, M-SCAFRATIO
    - Sub-B leave-one-scaffold-out (targets with ≥5 distinct active scaffolds):
      M-RECALL-HELDOUT-SCAFFOLD @ 1/5/10 %
    - Plots: enrichment curves (A + B), 4 metric heatmaps, EF5-vs-SCAFEF5 scatter
  - **Shared helpers:** `scafef_at_percent`, `recall_at_percent` added to
    `retrieval_common.py`.
  - **Docs:** reconciled the 37-vs-88 target discrepancy in PROJECT_PLAN.md §5.8
    and experimental_plan.md (ChEMBL_II ships 37; "88" was the original
    MUV+DUD+ChEMBL union without scaffold annotations).

  ## Validation
  Full run completed (job 21901216): 13 methods × 37 targets = 481 metrics.json,
  all plots generated, SUMMARY.md updated.

  ## Not in scope
  The §5.8 Wilcoxon success-criterion test (MUT vs B1 across targets) is part of
  the cross-experiment aggregation layer, which no experiment implements yet.

